### PR TITLE
Architecture deepening + perf wins: -700 LOC boilerplate, faster everywhere

### DIFF
--- a/src/api/com.atproto.admin.deleteAccount.ts
+++ b/src/api/com.atproto.admin.deleteAccount.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 import type { AuthRequest } from '../auth/types.js';
 import { requireRole } from '../auth/guards.js';
-import { query, getClient } from '../db/client.js';
+import { query, withTransaction } from '../db/client.js';
 import { auditLog } from '../db/audit.js';
 
 /**
@@ -56,10 +56,7 @@ export default async function adminDeleteAccount(req: AuthRequest, res: Response
     });
 
     // Delete all associated data in a transaction
-    const client = await getClient();
-    try {
-      await client.query('BEGIN');
-
+    await withTransaction(async (client) => {
       // Delete user repo data
       await client.query('DELETE FROM user_signing_keys WHERE user_did = $1', [user.did]);
       await client.query('DELETE FROM records_index WHERE community_did = $1', [user.did]);
@@ -79,14 +76,7 @@ export default async function adminDeleteAccount(req: AuthRequest, res: Response
 
       // Delete the user record
       await client.query('DELETE FROM users WHERE id = $1', [user.id]);
-
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
 
     res.status(200).json({ success: true });
   } catch (error) {

--- a/src/api/com.atproto.admin.deleteAccount.ts
+++ b/src/api/com.atproto.admin.deleteAccount.ts
@@ -3,6 +3,7 @@ import type { AuthRequest } from '../auth/types.js';
 import { requireRole } from '../auth/guards.js';
 import { query, withTransaction } from '../db/client.js';
 import { auditLog } from '../db/audit.js';
+import { invalidateAuthContext } from '../auth/auth-context-cache.js';
 
 /**
  * com.atproto.admin.deleteAccount
@@ -77,6 +78,8 @@ export default async function adminDeleteAccount(req: AuthRequest, res: Response
       // Delete the user record
       await client.query('DELETE FROM users WHERE id = $1', [user.id]);
     });
+
+    invalidateAuthContext(user.did);
 
     res.status(200).json({ success: true });
   } catch (error) {

--- a/src/api/com.atproto.admin.updateSubjectStatus.ts
+++ b/src/api/com.atproto.admin.updateSubjectStatus.ts
@@ -3,6 +3,7 @@ import type { AuthRequest } from '../auth/types.js';
 import { requireRole } from '../auth/guards.js';
 import { query } from '../db/client.js';
 import { auditLog } from '../db/audit.js';
+import { invalidateAuthContext } from '../auth/auth-context-cache.js';
 
 /**
  * com.atproto.admin.updateSubjectStatus
@@ -186,6 +187,11 @@ export default async function updateSubjectStatus(req: AuthRequest, res: Respons
     );
 
     const currentStatus = updated.rows[0]?.status || user.status;
+
+    // Cached AuthContext entries for OAuth/service-auth callers carry
+    // the old status — invalidate so the new state takes effect on the
+    // next request rather than after the 60s TTL.
+    invalidateAuthContext(did);
 
     res.status(200).json({
       subject: { $type: 'com.atproto.admin.defs#repoRef', did },

--- a/src/api/com.atproto.server.activateAccount.ts
+++ b/src/api/com.atproto.server.activateAccount.ts
@@ -3,6 +3,7 @@ import type { AuthRequest } from '../auth/types.js';
 import { requireAuth } from '../auth/guards.js';
 import { query } from '../db/client.js';
 import { auditLog } from '../db/audit.js';
+import { invalidateAuthContext } from '../auth/auth-context-cache.js';
 
 /**
  * com.atproto.server.activateAccount
@@ -68,6 +69,7 @@ export default async function activateAccount(req: AuthRequest, res: Response): 
     );
 
     await auditLog('account.activate', userId, userId, { did: userDid });
+    invalidateAuthContext(userDid);
 
     res.status(200).json({ success: true });
   } catch (error) {

--- a/src/api/com.atproto.server.deactivateAccount.ts
+++ b/src/api/com.atproto.server.deactivateAccount.ts
@@ -3,6 +3,7 @@ import type { AuthRequest } from '../auth/types.js';
 import { requireAuth } from '../auth/guards.js';
 import { query } from '../db/client.js';
 import { auditLog } from '../db/audit.js';
+import { invalidateAuthContext } from '../auth/auth-context-cache.js';
 
 /**
  * com.atproto.server.deactivateAccount
@@ -64,6 +65,7 @@ export default async function deactivateAccount(req: AuthRequest, res: Response)
     );
 
     await auditLog('account.deactivate', userId, userId, { did: userDid });
+    invalidateAuthContext(userDid);
 
     res.status(200).json({ success: true });
   } catch (error) {

--- a/src/api/net.openfederation.account.register.ts
+++ b/src/api/net.openfederation.account.register.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { config } from '../config.js';
-import { getClient } from '../db/client.js';
+import { withTransaction } from '../db/client.js';
 import { hashPassword } from '../auth/password.js';
 import { createUserIdentity } from '../identity/user-identity.js';
 import {
@@ -42,143 +42,116 @@ export default async function registerAccount(req: Request, res: Response): Prom
     return;
   }
 
-  const client = await getClient();
   try {
-    await client.query('BEGIN');
-    let inviteCodeToUse: string | null = null;
-    let inviteMaxUses: number | null = null;
-
-    try {
+    const result = await withTransaction(async (client) => {
       await ensureHandleEmailAvailable(client, handle, email);
-    } catch (err) {
-      await client.query('ROLLBACK');
-      if (err instanceof RegistrationValidationError) {
-        res.status(err.status).json({ error: err.code, message: err.message });
-        return;
-      }
-      throw err;
-    }
 
-    if (config.auth.inviteRequired) {
-      const inviteResult = await client.query<{
-        code: string;
-        max_uses: number;
-        uses_count: number;
-        expires_at: string | null;
-        bound_to: string | null;
-      }>(
-        `SELECT code, max_uses, uses_count, expires_at, bound_to
-         FROM invites
-         WHERE code = $1
-         FOR UPDATE`,
-        [input.inviteCode]
-      );
+      let inviteCodeToUse: string | null = null;
+      let inviteMaxUses: number | null = null;
 
-      if (inviteResult.rows.length === 0) {
-        await client.query('ROLLBACK');
-        res.status(403).json({
-          error: 'InviteInvalid',
-          message: 'Invite code is invalid',
-        });
-        return;
-      }
+      if (config.auth.inviteRequired) {
+        const inviteResult = await client.query<{
+          code: string;
+          max_uses: number;
+          uses_count: number;
+          expires_at: string | null;
+          bound_to: string | null;
+        }>(
+          `SELECT code, max_uses, uses_count, expires_at, bound_to
+           FROM invites
+           WHERE code = $1
+           FOR UPDATE`,
+          [input.inviteCode],
+        );
 
-      const invite = inviteResult.rows[0];
-      inviteCodeToUse = invite.code;
-      inviteMaxUses = invite.max_uses;
-      if (invite.expires_at && new Date(invite.expires_at).getTime() <= Date.now()) {
-        await client.query('ROLLBACK');
-        res.status(403).json({
-          error: 'InviteExpired',
-          message: 'Invite code has expired',
-        });
-        return;
-      }
-
-      if (invite.uses_count >= invite.max_uses) {
-        await client.query('ROLLBACK');
-        res.status(403).json({
-          error: 'InviteUsed',
-          message: 'Invite code has already been used',
-        });
-        return;
-      }
-
-      // Check email binding
-      if (invite.bound_to) {
-        const normalizedBound = invite.bound_to.toLowerCase().trim();
-        const normalizedEmail = input.email.toLowerCase().trim();
-        if (normalizedBound !== normalizedEmail) {
-          await client.query('ROLLBACK');
-          res.status(403).json({
-            error: 'InviteBound',
-            message: 'This invite code is bound to a specific email address.',
-          });
-          return;
+        if (inviteResult.rows.length === 0) {
+          throw new RegistrationValidationError(403, 'InviteInvalid', 'Invite code is invalid');
         }
+
+        const invite = inviteResult.rows[0];
+        if (invite.expires_at && new Date(invite.expires_at).getTime() <= Date.now()) {
+          throw new RegistrationValidationError(403, 'InviteExpired', 'Invite code has expired');
+        }
+        if (invite.uses_count >= invite.max_uses) {
+          throw new RegistrationValidationError(403, 'InviteUsed', 'Invite code has already been used');
+        }
+        if (invite.bound_to) {
+          const normalizedBound = invite.bound_to.toLowerCase().trim();
+          const normalizedEmail = input.email.toLowerCase().trim();
+          if (normalizedBound !== normalizedEmail) {
+            throw new RegistrationValidationError(
+              403,
+              'InviteBound',
+              'This invite code is bound to a specific email address.',
+            );
+          }
+        }
+
+        inviteCodeToUse = invite.code;
+        inviteMaxUses = invite.max_uses;
       }
-    }
 
-    // Create identity and hash password in parallel (independent operations)
-    let identity;
-    let passwordHash: string;
-    try {
-      [identity, passwordHash] = await Promise.all([
-        createUserIdentity(handle),
-        hashPassword(password),
-      ]);
-    } catch (err) {
-      await client.query('ROLLBACK');
-      console.error('Error creating user identity:', err);
-      res.status(500).json({
-        error: 'IdentityCreationFailed',
-        message: 'Failed to create user identity. Please try again.',
+      // Create identity and hash password in parallel (independent operations)
+      let identity;
+      let passwordHash: string;
+      try {
+        [identity, passwordHash] = await Promise.all([
+          createUserIdentity(handle),
+          hashPassword(password),
+        ]);
+      } catch (err) {
+        console.error('Error creating user identity:', err);
+        throw new RegistrationValidationError(
+          500,
+          'IdentityCreationFailed',
+          'Failed to create user identity. Please try again.',
+        );
+      }
+
+      const userId = crypto.randomUUID();
+
+      await insertUserWithRole(client, {
+        userId,
+        handle,
+        email,
+        passwordHash,
+        did: identity.did,
+        status: 'pending',
       });
-      return;
-    }
 
-    const userId = crypto.randomUUID();
+      if (inviteCodeToUse) {
+        const usedBy = inviteMaxUses === 1 ? userId : null;
+        await client.query(
+          `UPDATE invites
+           SET uses_count = uses_count + 1,
+               used_by = COALESCE($2, used_by),
+               used_at = CURRENT_TIMESTAMP
+           WHERE code = $1`,
+          [inviteCodeToUse, usedBy],
+        );
+      }
 
-    await insertUserWithRole(client, {
-      userId,
-      handle,
-      email,
-      passwordHash,
-      did: identity.did,
-      status: 'pending',
+      return { userId, identity };
     });
 
-    if (inviteCodeToUse) {
-      const usedBy = inviteMaxUses === 1 ? userId : null;
-      await client.query(
-        `UPDATE invites
-         SET uses_count = uses_count + 1,
-             used_by = COALESCE($2, used_by),
-             used_at = CURRENT_TIMESTAMP
-         WHERE code = $1`,
-        [inviteCodeToUse, usedBy]
-      );
-    }
-
-    await client.query('COMMIT');
-
-    await initializeUserRepoAsync(identity.did, handle, identity.signingKeyBase64);
+    await initializeUserRepoAsync(result.identity.did, handle, result.identity.signingKeyBase64);
 
     res.status(201).json({
-      id: userId,
+      id: result.userId,
       handle,
-      did: identity.did,
+      did: result.identity.did,
       email,
       status: 'pending',
     });
-  } catch (error) {
-    await client.query('ROLLBACK');
-    console.error('Error registering account:', error);
+  } catch (err) {
+    if (err instanceof RegistrationValidationError) {
+      res.status(err.status).json({ error: err.code, message: err.message });
+      return;
+    }
+    console.error('Error registering account:', err);
     res.status(500).json({
       error: 'InternalServerError',
       message: 'Failed to register account',
     });
-  } finally {
-    client.release();
   }
 }

--- a/src/api/net.openfederation.account.updateRoles.ts
+++ b/src/api/net.openfederation.account.updateRoles.ts
@@ -4,6 +4,7 @@ import type { UserRole } from '../auth/types.js';
 import { requireRole } from '../auth/guards.js';
 import { query } from '../db/client.js';
 import { auditLog } from '../db/audit.js';
+import { invalidateAuthContext } from '../auth/auth-context-cache.js';
 
 const VALID_ROLES: UserRole[] = ['admin', 'moderator', 'partner-manager', 'auditor', 'user'];
 
@@ -93,6 +94,8 @@ export default async function updateRoles(req: AuthRequest, res: Response): Prom
       removed: toRemove.length > 0 ? toRemove : undefined,
       currentRoles,
     });
+
+    invalidateAuthContext(user.did);
 
     res.status(200).json({
       did: user.did,

--- a/src/api/net.openfederation.community.delete.ts
+++ b/src/api/net.openfederation.community.delete.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 import type { AuthRequest } from '../auth/types.js';
 import { requireAuth } from '../auth/guards.js';
-import { query, getClient } from '../db/client.js';
+import { query, withTransaction } from '../db/client.js';
 import { auditLog } from '../db/audit.js';
 
 /**
@@ -43,10 +43,7 @@ export default async function deleteCommunity(req: AuthRequest, res: Response): 
     }
 
     // Delete all associated data in a transaction to prevent partial deletes
-    const client = await getClient();
-    try {
-      await client.query('BEGIN');
-
+    await withTransaction(async (client) => {
       // Delete in correct order (foreign key constraints)
       await client.query('DELETE FROM join_requests WHERE community_did = $1', [did]);
       await client.query('DELETE FROM members_unique WHERE community_did = $1', [did]);
@@ -57,14 +54,7 @@ export default async function deleteCommunity(req: AuthRequest, res: Response): 
       await client.query('DELETE FROM signing_keys WHERE community_did = $1', [did]);
       await client.query('DELETE FROM plc_keys WHERE community_did = $1', [did]);
       await client.query('DELETE FROM communities WHERE did = $1', [did]);
-
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
 
     await auditLog('community.delete', req.auth!.userId, did, {
       handle: communityResult.rows[0].handle,

--- a/src/api/net.openfederation.identity.setPrimaryWallet.ts
+++ b/src/api/net.openfederation.identity.setPrimaryWallet.ts
@@ -1,9 +1,12 @@
 import { Response } from 'express';
 import type { AuthRequest } from '../auth/types.js';
 import { requireApprovedUser } from '../auth/guards.js';
-import { getClient } from '../db/client.js';
+import { withTransaction } from '../db/client.js';
 import { auditLog } from '../db/audit.js';
 import { isWalletChain } from '../wallet/index.js';
+import { XrpcError, renderXrpcError } from '../xrpc/errors.js';
+
+const NSID = 'net.openfederation.identity.setPrimaryWallet';
 
 /**
  * POST net.openfederation.identity.setPrimaryWallet
@@ -30,10 +33,7 @@ export default async function setPrimaryWallet(req: AuthRequest, res: Response):
     const userDid = req.auth!.did;
     const addr = chain === 'ethereum' ? walletAddress.toLowerCase() : walletAddress;
 
-    const client = await getClient();
-    try {
-      await client.query('BEGIN');
-
+    await withTransaction(async (client) => {
       const owned = await client.query<{ id: string; custody_status: string }>(
         `SELECT id, custody_status FROM wallet_links
          WHERE user_did = $1 AND chain = $2 AND wallet_address = $3
@@ -41,17 +41,15 @@ export default async function setPrimaryWallet(req: AuthRequest, res: Response):
         [userDid, chain, addr]
       );
       if (owned.rows.length === 0) {
-        await client.query('ROLLBACK');
-        res.status(404).json({ error: 'WalletNotFound', message: 'No such wallet for this DID' });
-        return;
+        throw new XrpcError(NSID, 'WalletNotFound', 404, 'No such wallet for this DID');
       }
       if (owned.rows[0].custody_status !== 'active') {
-        await client.query('ROLLBACK');
-        res.status(409).json({
-          error: 'WalletInactive',
-          message: `Wallet is ${owned.rows[0].custody_status}; only active wallets can be primary`,
-        });
-        return;
+        throw new XrpcError(
+          NSID,
+          'WalletInactive',
+          409,
+          `Wallet is ${owned.rows[0].custody_status}; only active wallets can be primary`,
+        );
       }
 
       // Clear any existing primary on (user, chain), then set the new one.
@@ -67,14 +65,7 @@ export default async function setPrimaryWallet(req: AuthRequest, res: Response):
          WHERE id = $1`,
         [owned.rows[0].id]
       );
-
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
 
     await auditLog('identity.setPrimaryWallet', req.auth!.userId, userDid, {
       chain,
@@ -83,9 +74,7 @@ export default async function setPrimaryWallet(req: AuthRequest, res: Response):
 
     res.status(200).json({ chain, walletAddress: addr, isPrimary: true });
   } catch (err) {
-    console.error('Error in setPrimaryWallet:', err);
-    if (!res.headersSent) {
-      res.status(500).json({ error: 'InternalServerError', message: 'Failed to set primary wallet' });
-    }
+    if (res.headersSent) return;
+    renderXrpcError(NSID, res, err);
   }
 }

--- a/src/api/net.openfederation.identity.signInAssert.ts
+++ b/src/api/net.openfederation.identity.signInAssert.ts
@@ -1,7 +1,10 @@
 import { Response } from 'express';
 import type { AuthRequest } from '../auth/types.js';
 import { requireApprovedUser } from '../auth/guards.js';
-import { query, getClient } from '../db/client.js';
+import { query, withTransaction } from '../db/client.js';
+import { XrpcError, renderXrpcError } from '../xrpc/errors.js';
+
+const NSID = 'net.openfederation.identity.signInAssert';
 import { auditLog } from '../db/audit.js';
 import { parseSiwofMessage, normalizeSiwofAudience } from '../identity/siwof.js';
 import { verifyEthereumSignature } from '../identity/adapters/ethereum-verifier.js';
@@ -90,11 +93,12 @@ export default async function signInAssert(req: AuthRequest, res: Response): Pro
 
     // Look up + atomically consume the server-issued challenge. We match on
     // the exact message text so a dApp-tampered message (e.g. swapped audience
-    // or nonce) won't find a row.
-    const client = await getClient();
-    let audienceFromDb: string | null = null;
-    try {
-      await client.query('BEGIN');
+    // or nonce) won't find a row. Both the "valid" and "expired" branches
+    // commit the DELETE — only the "not found" branch can roll back, so we
+    // throw before any mutation runs.
+    const consume = await withTransaction<
+      { outcome: 'valid'; audience: string | null } | { outcome: 'expired' }
+    >(async (client) => {
       const ch = await client.query<{ id: string; expired: boolean; audience: string | null }>(
         `SELECT id, (expires_at < NOW()) AS expired, audience
          FROM wallet_link_challenges
@@ -104,26 +108,21 @@ export default async function signInAssert(req: AuthRequest, res: Response): Pro
         [userDid, chain, addr, message]
       );
       if (ch.rows.length === 0) {
-        await client.query('ROLLBACK');
-        res.status(404).json({ error: 'ChallengeNotFound', message: 'No matching SIWOF challenge for this DID + wallet + message' });
-        return;
+        throw new XrpcError(NSID, 'ChallengeNotFound', 404, 'No matching SIWOF challenge for this DID + wallet + message');
       }
-      if (ch.rows[0].expired) {
-        await client.query('DELETE FROM wallet_link_challenges WHERE id = $1', [ch.rows[0].id]);
-        await client.query('COMMIT');
-        res.status(401).json({ error: 'ChallengeExpired', message: 'SIWOF challenge has expired' });
-        return;
-      }
-      audienceFromDb = ch.rows[0].audience;
-      // One-shot use: consume the challenge so the message can't be replayed.
+      // One-shot use: consume the challenge whether or not it's expired.
       await client.query('DELETE FROM wallet_link_challenges WHERE id = $1', [ch.rows[0].id]);
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
+      if (ch.rows[0].expired) {
+        return { outcome: 'expired' };
+      }
+      return { outcome: 'valid', audience: ch.rows[0].audience };
+    });
+
+    if (consume.outcome === 'expired') {
+      res.status(401).json({ error: 'ChallengeExpired', message: 'SIWOF challenge has expired' });
+      return;
     }
+    const audienceFromDb = consume.audience;
 
     // Defense in depth: message URI must agree with the audience the challenge
     // was issued against.
@@ -178,9 +177,7 @@ export default async function signInAssert(req: AuthRequest, res: Response): Pro
       audience: messageAudience.uri,
     });
   } catch (err) {
-    console.error('Error in signInAssert:', err);
-    if (!res.headersSent) {
-      res.status(500).json({ error: 'InternalServerError', message: 'Failed to assert sign-in' });
-    }
+    if (res.headersSent) return;
+    renderXrpcError(NSID, res, err);
   }
 }

--- a/src/api/net.openfederation.partner.register.ts
+++ b/src/api/net.openfederation.partner.register.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 import type { AuthRequest } from '../auth/types.js';
 import { requirePartnerAuth } from '../auth/guards.js';
-import { getClient, query } from '../db/client.js';
+import { query, withTransaction } from '../db/client.js';
 import { hashPassword } from '../auth/password.js';
 import { signAccessToken, generateRefreshToken, refreshTtlMs } from '../auth/tokens.js';
 import { createUserIdentity } from '../identity/user-identity.js';
@@ -24,7 +24,7 @@ interface PartnerRegisterInput {
 
 export default async function partnerRegister(req: AuthRequest, res: Response): Promise<void> {
   if (!requirePartnerAuth(req, res, 'register')) return;
-  const partner = req.partnerAuth;
+  const partner = req.partnerAuth!;
 
   const input: PartnerRegisterInput = req.body;
 
@@ -45,7 +45,7 @@ export default async function partnerRegister(req: AuthRequest, res: Response): 
     `SELECT COUNT(*) as count FROM users
      WHERE created_by_partner = $1
      AND created_at > CURRENT_TIMESTAMP - INTERVAL '1 hour'`,
-    [partner.partnerId]
+    [partner.partnerId],
   );
   const recentCount = parseInt(rateResult.rows[0].count, 10);
   if (recentCount >= partner.rateLimitPerHour) {
@@ -56,67 +56,53 @@ export default async function partnerRegister(req: AuthRequest, res: Response): 
     return;
   }
 
-  const client = await getClient();
   try {
-    await client.query('BEGIN');
-
-    try {
+    const result = await withTransaction(async (client) => {
       await ensureHandleEmailAvailable(client, handle, email);
-    } catch (err) {
-      await client.query('ROLLBACK');
-      if (err instanceof RegistrationValidationError) {
-        res.status(err.status).json({ error: err.code, message: err.message });
-        return;
+
+      let identity;
+      let passwordHash: string;
+      try {
+        [identity, passwordHash] = await Promise.all([
+          createUserIdentity(handle),
+          hashPassword(password),
+        ]);
+      } catch (err) {
+        console.error('Error creating user identity (partner register):', err);
+        throw new RegistrationValidationError(
+          500,
+          'IdentityCreationFailed',
+          'Failed to create user identity. Please try again.',
+        );
       }
-      throw err;
-    }
 
-    // Create identity and hash password in parallel (independent operations)
-    let identity;
-    let passwordHash: string;
-    try {
-      [identity, passwordHash] = await Promise.all([
-        createUserIdentity(handle),
-        hashPassword(password),
-      ]);
-    } catch (err) {
-      await client.query('ROLLBACK');
-      console.error('Error creating user identity (partner register):', err);
-      res.status(500).json({
-        error: 'IdentityCreationFailed',
-        message: 'Failed to create user identity. Please try again.',
+      const userId = crypto.randomUUID();
+
+      await insertUserWithRole(client, {
+        userId,
+        handle,
+        email,
+        passwordHash,
+        did: identity.did,
+        status: 'approved',
+        createdByPartner: partner.partnerId,
       });
-      return;
-    }
 
-    const userId = crypto.randomUUID();
+      await client.query(
+        `UPDATE partner_keys SET total_registrations = total_registrations + 1 WHERE id = $1`,
+        [partner.partnerId],
+      );
 
-    await insertUserWithRole(client, {
-      userId,
-      handle,
-      email,
-      passwordHash,
-      did: identity.did,
-      status: 'approved',
-      createdByPartner: partner.partnerId,
+      return { userId, identity };
     });
 
-    // Increment partner registration count
-    await client.query(
-      `UPDATE partner_keys SET total_registrations = total_registrations + 1 WHERE id = $1`,
-      [partner.partnerId]
-    );
+    await initializeUserRepoAsync(result.identity.did, handle, result.identity.signingKeyBase64);
 
-    await client.query('COMMIT');
-
-    await initializeUserRepoAsync(identity.did, handle, identity.signingKeyBase64);
-
-    // Create session and issue tokens
     const accessJwt = await signAccessToken({
-      userId,
+      userId: result.userId,
       handle,
       email,
-      did: identity.did,
+      did: result.identity.did,
       status: 'approved' as UserStatus,
       roles: ['user'],
     });
@@ -128,34 +114,34 @@ export default async function partnerRegister(req: AuthRequest, res: Response): 
     await query(
       `INSERT INTO sessions (id, user_id, refresh_token_hash, expires_at)
        VALUES ($1, $2, $3, $4)`,
-      [sessionId, userId, hash, expiresAt.toISOString()]
+      [sessionId, result.userId, hash, expiresAt.toISOString()],
     );
 
-    // Audit log (fire-and-forget)
-    auditLog('partner.register', partner.partnerId, userId, {
+    auditLog('partner.register', partner.partnerId, result.userId, {
       handle,
       partnerName: partner.partnerName,
-      did: identity.did,
+      did: result.identity.did,
     }).catch(() => {});
 
     res.status(201).json({
-      id: userId,
+      id: result.userId,
       handle,
-      did: identity.did,
+      did: result.identity.did,
       email,
       status: 'approved',
       accessJwt,
       refreshJwt,
       active: true,
     });
-  } catch (error) {
-    await client.query('ROLLBACK');
-    console.error('Error in partner registration:', error);
+  } catch (err) {
+    if (err instanceof RegistrationValidationError) {
+      res.status(err.status).json({ error: err.code, message: err.message });
+      return;
+    }
+    console.error('Error in partner registration:', err);
     res.status(500).json({
       error: 'InternalServerError',
       message: 'Failed to register account',
     });
-  } finally {
-    client.release();
   }
 }

--- a/src/api/net.openfederation.vault.registerEscrow.ts
+++ b/src/api/net.openfederation.vault.registerEscrow.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 import type { AuthRequest } from '../auth/types.js';
 import { requireAuth, requireApprovedUser } from '../auth/guards.js';
 import { logVaultAudit, getUserShares } from '../vault/vault-store.js';
-import { getClient } from '../db/client.js';
+import { withTransaction } from '../db/client.js';
 
 const DID_PATTERN = /^did:[a-z]+:.+$/;
 
@@ -56,10 +56,7 @@ export default async function registerEscrow(req: AuthRequest, res: Response): P
     }
 
     // Wrap all mutations in a transaction to prevent partial state
-    const client = await getClient();
-    try {
-      await client.query('BEGIN');
-
+    await withTransaction(async (client) => {
       // Register escrow provider if not already registered
       const existingProvider = await client.query(
         'SELECT id FROM escrow_providers WHERE did = $1',
@@ -88,14 +85,7 @@ export default async function registerEscrow(req: AuthRequest, res: Response): P
          WHERE user_did = $2`,
         [2, userDid]
       );
-
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
 
     // Audit the escrow registration (outside transaction — non-critical)
     await logVaultAudit(userDid, 'escrow.registered', userDid, 3, {

--- a/src/api/net.openfederation.wallet.finalizeTierChange.ts
+++ b/src/api/net.openfederation.wallet.finalizeTierChange.ts
@@ -2,9 +2,12 @@ import { Response } from 'express';
 import type { AuthRequest } from '../auth/types.js';
 import { requireApprovedUser } from '../auth/guards.js';
 import { verifyPassword } from '../auth/password.js';
-import { getClient, query } from '../db/client.js';
+import { query, withTransaction } from '../db/client.js';
 import { auditLog } from '../db/audit.js';
 import { isWalletChain, isCustodyTier } from '../wallet/index.js';
+import { XrpcError, renderXrpcError } from '../xrpc/errors.js';
+
+const NSID = 'net.openfederation.wallet.finalizeTierChange';
 
 const MAX_BLOB_LEN = 65536; // matches custodial_secrets TEXT blob cap
 
@@ -97,10 +100,7 @@ export default async function finalizeTierChange(req: AuthRequest, res: Response
       return;
     }
 
-    const client = await getClient();
-    try {
-      await client.query('BEGIN');
-
+    const previousTier = await withTransaction<string>(async (client) => {
       const tierRow = await client.query<{ custody_tier: string; custody_status: string }>(
         `SELECT custody_tier, custody_status FROM wallet_links
          WHERE user_did = $1 AND chain = $2 AND wallet_address = $3
@@ -108,14 +108,10 @@ export default async function finalizeTierChange(req: AuthRequest, res: Response
         [userDid, chain, addr]
       );
       if (tierRow.rows.length === 0) {
-        await client.query('ROLLBACK');
-        res.status(404).json({ error: 'WalletNotFound', message: 'No such wallet for this DID' });
-        return;
+        throw new XrpcError(NSID, 'WalletNotFound', 404, 'No such wallet for this DID');
       }
       if (tierRow.rows[0].custody_status !== 'active') {
-        await client.query('ROLLBACK');
-        res.status(409).json({ error: 'WalletInactive', message: `Wallet is ${tierRow.rows[0].custody_status}` });
-        return;
+        throw new XrpcError(NSID, 'WalletInactive', 409, `Wallet is ${tierRow.rows[0].custody_status}`);
       }
 
       const currentTier = tierRow.rows[0].custody_tier;
@@ -125,12 +121,12 @@ export default async function finalizeTierChange(req: AuthRequest, res: Response
         (currentTier === 'custodial' && (newTier === 'user_encrypted' || newTier === 'self_custody')) ||
         (currentTier === 'user_encrypted' && newTier === 'self_custody');
       if (!allowed) {
-        await client.query('ROLLBACK');
-        res.status(409).json({
-          error: 'UnsupportedTransition',
-          message: `Cannot transition ${currentTier} → ${newTier}; tier upgrades are one-way (1→2, 1→3, 2→3). Create a new wallet for other transitions.`,
-        });
-        return;
+        throw new XrpcError(
+          NSID,
+          'UnsupportedTransition',
+          409,
+          `Cannot transition ${currentTier} → ${newTier}; tier upgrades are one-way (1→2, 1→3, 2→3). Create a new wallet for other transitions.`,
+        );
       }
 
       // 1. Drop the existing custody record for the current tier.
@@ -181,31 +177,24 @@ export default async function finalizeTierChange(req: AuthRequest, res: Response
         [userDid, chain, addr]
       );
 
-      await client.query('COMMIT');
+      return currentTier;
+    });
 
-      await auditLog('wallet.tierChange', userId, userDid, {
-        chain,
-        walletAddress: addr,
-        from: currentTier,
-        to: newTier,
-      });
+    await auditLog('wallet.tierChange', userId, userDid, {
+      chain,
+      walletAddress: addr,
+      from: previousTier,
+      to: newTier,
+    });
 
-      res.status(200).json({
-        chain,
-        walletAddress: addr,
-        previousTier: currentTier,
-        newTier,
-      });
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    res.status(200).json({
+      chain,
+      walletAddress: addr,
+      previousTier,
+      newTier,
+    });
   } catch (err) {
-    console.error('Error in finalizeTierChange:', err);
-    if (!res.headersSent) {
-      res.status(500).json({ error: 'InternalServerError', message: 'Failed to finalize tier change' });
-    }
+    if (res.headersSent) return;
+    renderXrpcError(NSID, res, err);
   }
 }

--- a/src/api/net.openfederation.wallet.sign.ts
+++ b/src/api/net.openfederation.wallet.sign.ts
@@ -4,10 +4,10 @@ import { requireApprovedUser } from '../auth/guards.js';
 import { auditLog } from '../db/audit.js';
 import {
   signWithCustodialKey,
-  hasActiveConsent,
-  getWalletTier,
   isWalletChain,
   normalizeDappOrigin,
+  assertCustodialSigningEligible,
+  WalletEligibilityRejection,
 } from '../wallet/index.js';
 
 /**
@@ -71,46 +71,22 @@ export default async function walletSign(req: AuthRequest, res: Response): Promi
     const userId = req.auth!.userId;
     const normalizedAddress = chain === 'ethereum' ? walletAddress.toLowerCase() : walletAddress;
 
-    // 1. Wallet must exist, belong to this user, and be Tier 1.
-    const tierInfo = await getWalletTier(userDid, chain, normalizedAddress);
-    if (!tierInfo) {
-      res.status(404).json({ error: 'WalletNotFound', message: 'No such wallet for this DID' });
-      return;
-    }
-    if (tierInfo.status !== 'active') {
-      res.status(409).json({
-        error: 'WalletInactive',
-        message: `Wallet is ${tierInfo.status} and cannot be signed with`,
+    try {
+      await assertCustodialSigningEligible({
+        userDid,
+        chain,
+        walletAddress: normalizedAddress,
+        dappOrigin: origin,
       });
-      return;
-    }
-    if (tierInfo.tier !== 'custodial') {
-      res.status(409).json({
-        error: 'UnsupportedTier',
-        message:
-          tierInfo.tier === 'user_encrypted'
-            ? 'Tier 2 wallets must sign client-side via the SDK (unlock + signMessage)'
-            : 'Tier 3 wallets are self-custodial — use your own wallet software to sign',
-      });
-      return;
+    } catch (err) {
+      if (err instanceof WalletEligibilityRejection) {
+        res.status(err.status).json({ error: err.code, message: err.message });
+        return;
+      }
+      throw err;
     }
 
-    // 2. Consent must exist for this dApp + wallet combination.
-    const consented = await hasActiveConsent({
-      userDid,
-      dappOrigin: origin,
-      chain,
-      walletAddress: normalizedAddress,
-    });
-    if (!consented) {
-      res.status(403).json({
-        error: 'ConsentRequired',
-        message: 'No active consent grants this dApp permission to sign with this wallet',
-      });
-      return;
-    }
-
-    // 3. Sign.
+    // Sign.
     const signature = await signWithCustodialKey({
       userDid,
       chain,

--- a/src/api/net.openfederation.wallet.signTransaction.ts
+++ b/src/api/net.openfederation.wallet.signTransaction.ts
@@ -3,13 +3,15 @@ import type { AuthRequest } from '../auth/types.js';
 import { requireApprovedUser } from '../auth/guards.js';
 import { auditLog } from '../db/audit.js';
 import {
-  hasActiveConsent,
-  getWalletTier,
+  assertCustodialSigningEligible,
   isWalletChain,
   normalizeDappOrigin,
   signTransactionWithCustodialKey,
+  WalletEligibilityRejection,
   type EvmTransactionRequest,
 } from '../wallet/index.js';
+
+const NSID = 'net.openfederation.wallet.signTransaction';
 
 const MAX_EVM_DATA_HEX = 2 * 128 * 1024 + 2; // 128KB of bytes, plus 0x-prefix
 const MAX_SOL_MESSAGE_B64 = Math.ceil((128 * 1024 * 4) / 3); // 128KB of bytes
@@ -98,37 +100,19 @@ export default async function walletSignTransaction(req: AuthRequest, res: Respo
     const userId = req.auth!.userId;
     const normalizedAddress = chain === 'ethereum' ? walletAddress.toLowerCase() : walletAddress;
 
-    // Tier + status check — mirrors `wallet.sign`. Tier 1 only.
-    const tierInfo = await getWalletTier(userDid, chain, normalizedAddress);
-    if (!tierInfo) {
-      res.status(404).json({ error: 'WalletNotFound', message: 'No such wallet for this DID' });
-      return;
-    }
-    if (tierInfo.status !== 'active') {
-      res.status(409).json({ error: 'WalletInactive', message: `Wallet is ${tierInfo.status} and cannot be signed with` });
-      return;
-    }
-    if (tierInfo.tier !== 'custodial') {
-      res.status(409).json({
-        error: 'UnsupportedTier',
-        message:
-          tierInfo.tier === 'user_encrypted'
-            ? 'Tier 2 wallets must sign client-side via the SDK'
-            : 'Tier 3 wallets are self-custodial — use your own wallet software to sign',
+    try {
+      await assertCustodialSigningEligible({
+        userDid,
+        chain,
+        walletAddress: normalizedAddress,
+        dappOrigin: origin,
       });
-      return;
-    }
-
-    // Consent check.
-    const consented = await hasActiveConsent({
-      userDid,
-      dappOrigin: origin,
-      chain,
-      walletAddress: normalizedAddress,
-    });
-    if (!consented) {
-      res.status(403).json({ error: 'ConsentRequired', message: 'No active consent grants this dApp permission to sign with this wallet' });
-      return;
+    } catch (err) {
+      if (err instanceof WalletEligibilityRejection) {
+        res.status(err.status).json({ error: err.code, message: err.message });
+        return;
+      }
+      throw err;
     }
 
     // Sign.
@@ -161,7 +145,7 @@ export default async function walletSignTransaction(req: AuthRequest, res: Respo
       res.status(200).json({ chain, walletAddress: normalizedAddress, signature: result, dappOrigin: origin });
     }
   } catch (err) {
-    console.error('Error in walletSignTransaction:', err);
+    console.error(`Error in ${NSID}:`, err);
     if (!res.headersSent) {
       res.status(500).json({ error: 'InternalServerError', message: 'Failed to sign transaction' });
     }

--- a/src/auth/auth-context-cache.ts
+++ b/src/auth/auth-context-cache.ts
@@ -1,0 +1,81 @@
+/**
+ * In-process cache for the AuthContext synthesised from a DID for OAuth
+ * and service-auth requests.
+ *
+ * Local Bearer JWT auth doesn't pay this cost — the JWT payload IS the
+ * AuthContext. But OAuth (DPoP) and service-auth (cross-PDS federation)
+ * require resolving DID → user record → roles, which is two sequential
+ * SQL queries on every request. For SDK clients firing 4-6 requests per
+ * page, that's 8-12 round-trips of overhead.
+ *
+ * The TTL is intentionally short (60s) — much shorter than the local
+ * Bearer access-token lifetime — so the security model around suspends/
+ * status changes isn't weakened. A user suspended right now still gets
+ * up to 60s of grace under cached auth, but a local Bearer JWT user
+ * gets up to ~15 minutes of grace until their access token expires, so
+ * the cache window is the tighter bound.
+ *
+ * Cache size is bounded by simple eviction when the limit is hit; the
+ * Map iteration order gives us oldest-insert-first ≈ LRU enough.
+ */
+
+import type { AuthContext } from './types.js';
+
+const TTL_MS = 60 * 1000;
+const MAX_ENTRIES = 5_000;
+
+type CacheKey = string; // `${authMethod}:${did}` — separate caches by auth method
+
+interface Entry {
+  context: AuthContext;
+  expiresAt: number;
+}
+
+const cache = new Map<CacheKey, Entry>();
+
+function key(authMethod: string, did: string): CacheKey {
+  return `${authMethod}:${did}`;
+}
+
+export function getCachedAuthContext(
+  authMethod: 'oauth' | 'service-auth',
+  did: string,
+): AuthContext | null {
+  const entry = cache.get(key(authMethod, did));
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key(authMethod, did));
+    return null;
+  }
+  return entry.context;
+}
+
+export function setCachedAuthContext(
+  authMethod: 'oauth' | 'service-auth',
+  did: string,
+  context: AuthContext,
+): void {
+  if (cache.size >= MAX_ENTRIES) {
+    // Evict the oldest insertion. Map iteration is insertion order, so
+    // the first key in the iterator is the oldest.
+    const firstKey = cache.keys().next().value;
+    if (firstKey) cache.delete(firstKey);
+  }
+  cache.set(key(authMethod, did), { context, expiresAt: Date.now() + TTL_MS });
+}
+
+/**
+ * Drop all cached AuthContext entries for a DID. Call from endpoints
+ * that change user status or roles (admin.updateSubjectStatus,
+ * account.updateRoles, account.deleteAccount, etc.) so changes take
+ * effect immediately rather than waiting for the TTL.
+ */
+export function invalidateAuthContext(did: string): void {
+  cache.delete(key('oauth', did));
+  cache.delete(key('service-auth', did));
+}
+
+/** Test helper — not exported via index. */
+export function _clearAuthContextCache(): void {
+  cache.clear();
+}

--- a/src/auth/partner-guard.ts
+++ b/src/auth/partner-guard.ts
@@ -31,18 +31,17 @@ export async function validatePartnerKey(
   return result.partner;
 }
 
-// Cached partner origins for CORS (5-min TTL)
+// Cached partner origins for CORS (5-min TTL).
+// `inFlight` deduplicates concurrent refreshes: when the TTL expires
+// under load, every arriving request would otherwise trigger its own
+// SELECT. With dedup, the first miss owns the refresh and the rest
+// await the same promise.
 let cachedOrigins: string[] = [];
 let cachedAt = 0;
+let inFlight: Promise<string[]> | null = null;
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
-/**
- * Get all allowed origins from active partner keys (cached 5 min).
- */
-export async function getCachedPartnerOrigins(): Promise<string[]> {
-  if (Date.now() - cachedAt < CACHE_TTL_MS) {
-    return cachedOrigins;
-  }
+async function refreshPartnerOrigins(): Promise<string[]> {
   try {
     const result = await query<{ allowed_origins: string[] | null }>(
       `SELECT allowed_origins FROM partner_keys
@@ -62,4 +61,18 @@ export async function getCachedPartnerOrigins(): Promise<string[]> {
     // On error, keep stale cache rather than breaking CORS
   }
   return cachedOrigins;
+}
+
+/**
+ * Get all allowed origins from active partner keys (cached 5 min).
+ */
+export async function getCachedPartnerOrigins(): Promise<string[]> {
+  if (Date.now() - cachedAt < CACHE_TTL_MS) {
+    return cachedOrigins;
+  }
+  if (inFlight) return inFlight;
+  inFlight = refreshPartnerOrigins().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
 }

--- a/src/auth/verification.ts
+++ b/src/auth/verification.ts
@@ -12,6 +12,7 @@ import { isValidPartnerKeyFormat, hashPartnerKey } from './partner-keys.js';
 import { isValidOracleKeyFormat, hashOracleKey } from './oracle-keys.js';
 import type { PartnerContext } from './partner-guard.js';
 import type { OracleContext } from './oracle-guard.js';
+import { getCachedAuthContext, setCachedAuthContext } from './auth-context-cache.js';
 
 type OAuthVerifier = {
   authenticateRequest(
@@ -160,6 +161,12 @@ async function authContextForLocalDid(
   did: string,
   authMethod: 'oauth' | 'service-auth',
 ): Promise<AuthContext | null> {
+  const cached = getCachedAuthContext(authMethod, did);
+  if (cached) return cached;
+
+  // Two queries on cache miss (sequential because the second one needs
+  // user.id from the first). The cache absorbs the cost across the next
+  // 60s of requests for the same DID.
   const userResult = await query<{ id: string; handle: string; email: string; status: string }>(
     'SELECT id, handle, email, status FROM users WHERE did = $1',
     [did],
@@ -173,7 +180,7 @@ async function authContextForLocalDid(
     [user.id],
   );
 
-  return {
+  const context: AuthContext = {
     userId: user.id,
     handle: user.handle,
     email: user.email || '',
@@ -182,6 +189,8 @@ async function authContextForLocalDid(
     roles: roleResult.rows.map(r => r.role) as UserRole[],
     authMethod,
   };
+  setCachedAuthContext(authMethod, did, context);
+  return context;
 }
 
 interface PartnerRow {

--- a/src/community/display-projection.ts
+++ b/src/community/display-projection.ts
@@ -92,37 +92,3 @@ export async function fanOutDisplayFields(
   );
 }
 
-/**
- * Sync the role / kind / tags / attributes columns on a single members_unique
- * row from the values that were just written to records_index.
- */
-export async function syncMemberRoleProjection(
-  communityDid: string,
-  memberDid: string,
-  fields: {
-    role?: string | null;
-    roleRkey?: string | null;
-    kind?: string | null;
-    tags?: string[] | null;
-    attributes?: Record<string, unknown> | null;
-  },
-): Promise<void> {
-  await query(
-    `UPDATE members_unique
-     SET role      = COALESCE($3, role),
-         role_rkey = $4,
-         kind      = $5,
-         tags      = $6,
-         attributes = $7
-     WHERE community_did = $1 AND member_did = $2`,
-    [
-      communityDid,
-      memberDid,
-      fields.role ?? null,
-      fields.roleRkey ?? null,
-      fields.kind ?? null,
-      fields.tags ? JSON.stringify(fields.tags) : null,
-      fields.attributes ? JSON.stringify(fields.attributes) : null,
-    ],
-  );
-}

--- a/src/community/membership/update.ts
+++ b/src/community/membership/update.ts
@@ -7,7 +7,6 @@ import { throwXrpc } from '../../xrpc/errors.js';
 import { auditLog } from '../../db/audit.js';
 import { getCallerCommunityCapabilities } from '../visibility.js';
 import { requireString } from './utils.js';
-import { syncMemberRoleProjection } from '../display-projection.js';
 
 const UPDATE_MEMBER_NSID = 'net.openfederation.community.updateMember';
 const MAX_KIND_LENGTH = 64;
@@ -272,14 +271,8 @@ export async function updateMemberLifecycle(
   const keypair = await getKeypairForDid(communityDid);
   const result = await engine.putRecord(keypair, MEMBER_COLLECTION, memberRkey, next);
 
-  // Sync projection columns that changed
-  await syncMemberRoleProjection(communityDid, memberDid, {
-    role: next.role ?? null,
-    roleRkey: next.roleRkey ?? null,
-    kind: next.kind ?? null,
-    tags: next.tags ?? null,
-    attributes: next.attributes ?? null,
-  });
+  // Projection columns (role/role_rkey/kind/tags/attributes) are synced
+  // automatically by RepoEngine.syncRecordsIndex from the member record.
 
   await auditLog('community.updateMember', caller.userId, communityDid, {
     memberDid,

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -39,6 +39,39 @@ export async function getClient(): Promise<PoolClient> {
   return pool.connect();
 }
 
+/**
+ * Run `fn` inside a database transaction. The callback receives the
+ * transaction client and may issue any queries on it. Returning a value
+ * commits the transaction; throwing rolls it back. The connection is
+ * always released, regardless of outcome.
+ *
+ * Throw a typed error (e.g. `RegistrationValidationError`) from the
+ * callback to signal a domain failure — the caller catches it after the
+ * rollback has already happened. Do not send HTTP responses from inside
+ * the callback; do that at the call site after `withTransaction` returns
+ * or rejects.
+ */
+export async function withTransaction<T>(
+  fn: (client: PoolClient) => Promise<T>,
+): Promise<T> {
+  const client = await getClient();
+  try {
+    await client.query('BEGIN');
+    const result = await fn(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (err) {
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackErr) {
+      console.error('Rollback failed after transaction error:', rollbackErr);
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 export async function closePool(): Promise<void> {
   if (pool) {
     await pool.end();

--- a/src/identity/external-handle-resolver.ts
+++ b/src/identity/external-handle-resolver.ts
@@ -1,25 +1,33 @@
 import dns from 'dns/promises';
 
-const CACHE = new Map<string, { did: string; expiresAt: number }>();
-const TTL_MS = 60 * 60 * 1000; // 1 hour
-const TIMEOUT_MS = 3000;
+type CacheEntry =
+  | { kind: 'hit'; did: string; expiresAt: number }
+  | { kind: 'miss'; expiresAt: number };
 
-function cached(handle: string): string | null {
+const CACHE = new Map<string, CacheEntry>();
+const TTL_HIT_MS = 60 * 60 * 1000;       // 1 hour for successful resolutions
+const TTL_MISS_MS = 60 * 1000;           // 1 minute for failures — short enough
+                                         // that legitimate fixes propagate fast,
+                                         // long enough to absorb retry storms
+                                         // from typo'd handles
+const TIMEOUT_MS = 2000;                 // overall cap; well-known is the slow leg
+
+function cached(handle: string): { hit: true; did: string | null } | { hit: false } {
   const entry = CACHE.get(handle);
-  if (!entry) return null;
-  if (Date.now() > entry.expiresAt) { CACHE.delete(handle); return null; }
-  return entry.did;
+  if (!entry) return { hit: false };
+  if (Date.now() > entry.expiresAt) {
+    CACHE.delete(handle);
+    return { hit: false };
+  }
+  return { hit: true, did: entry.kind === 'hit' ? entry.did : null };
 }
 
-function cache(handle: string, did: string): void {
-  CACHE.set(handle, { did, expiresAt: Date.now() + TTL_MS });
+function cacheHit(handle: string, did: string): void {
+  CACHE.set(handle, { kind: 'hit', did, expiresAt: Date.now() + TTL_HIT_MS });
 }
 
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
-  return Promise.race([
-    promise,
-    new Promise<null>(resolve => setTimeout(() => resolve(null), ms)),
-  ]);
+function cacheMiss(handle: string): void {
+  CACHE.set(handle, { kind: 'miss', expiresAt: Date.now() + TTL_MISS_MS });
 }
 
 async function tryDnsTxt(handle: string): Promise<string | null> {
@@ -34,44 +42,62 @@ async function tryDnsTxt(handle: string): Promise<string | null> {
   return null;
 }
 
-async function tryWellKnown(handle: string): Promise<string | null> {
+async function tryWellKnown(handle: string, signal: AbortSignal): Promise<string | null> {
   try {
     const url = `https://${handle}/.well-known/atproto-did`;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-    try {
-      const res = await fetch(url, { signal: controller.signal });
-      if (!res.ok) return null;
-      const text = (await res.text()).trim();
-      return text.startsWith('did:') ? text : null;
-    } finally {
-      clearTimeout(timer);
-    }
-  } catch { /* network error */ }
+    const res = await fetch(url, { signal });
+    if (!res.ok) return null;
+    const text = (await res.text()).trim();
+    return text.startsWith('did:') ? text : null;
+  } catch { /* network error or abort */ }
   return null;
 }
 
 /**
  * Resolve a handle that isn't local to this PDS.
- * Tries DNS TXT first (faster, no HTTP), then HTTPS well-known.
- * Results are cached for 1 hour.
+ *
+ * Both legs (DNS TXT + HTTPS well-known) race in parallel; the first
+ * non-null answer wins, the loser is aborted. Total latency is bounded
+ * by `TIMEOUT_MS` (2s) and in practice settles well under that — DNS
+ * usually answers in <100ms when the record exists.
+ *
+ * Successful resolutions are cached for 1 hour. Failures are cached for
+ * 1 minute so a typo or down host doesn't force every subsequent retry
+ * to wait the full timeout.
  */
 export async function resolveExternalHandle(handle: string): Promise<string | null> {
   const hit = cached(handle);
-  if (hit) return hit;
+  if (hit.hit) return hit.did;
 
   // Skip obviously local-looking handles (no dot = bare handle, not a domain)
   if (!handle.includes('.')) return null;
 
-  const did = await withTimeout(
-    (async () => {
-      const fromDns = await tryDnsTxt(handle);
-      if (fromDns) return fromDns;
-      return tryWellKnown(handle);
-    })(),
-    TIMEOUT_MS,
-  );
+  const controller = new AbortController();
+  const overallTimer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
-  if (did) cache(handle, did);
-  return did;
+  try {
+    // Race DNS and well-known. The first non-null wins.
+    const did = await new Promise<string | null>((resolve) => {
+      let pending = 2;
+      const settle = (value: string | null) => {
+        if (value) {
+          resolve(value);
+          return;
+        }
+        if (--pending === 0) resolve(null);
+      };
+      tryDnsTxt(handle).then(settle, () => settle(null));
+      tryWellKnown(handle, controller.signal).then(settle, () => settle(null));
+    });
+
+    if (did) {
+      cacheHit(handle, did);
+    } else {
+      cacheMiss(handle);
+    }
+    return did;
+  } finally {
+    clearTimeout(overallTimer);
+    controller.abort();
+  }
 }

--- a/src/identity/wallet-link.ts
+++ b/src/identity/wallet-link.ts
@@ -6,7 +6,13 @@
  */
 
 import { randomUUID, randomBytes } from 'crypto';
-import { query, getClient } from '../db/client.js';
+import { query, withTransaction } from '../db/client.js';
+
+class WalletLinkRejection extends Error {
+  constructor(public readonly reason: string) {
+    super(reason);
+  }
+}
 import { verifyEthereumSignature } from './adapters/ethereum-verifier.js';
 import { verifySolanaSignature } from './adapters/solana-verifier.js';
 
@@ -85,91 +91,95 @@ export async function verifyAndLink(
     return { success: false, error: 'Signature verification failed' };
   }
 
-  // 2. Use a transaction for all DB operations to prevent TOCTOU races
-  const client = await getClient();
+  // 2. Use a transaction for all DB operations to prevent TOCTOU races.
+  // The expired-challenge branch commits the DELETE then signals failure
+  // via a discriminated return; other rejections throw WalletLinkRejection
+  // to roll back.
   try {
-    await client.query('BEGIN');
-
-    // Lock the challenge row to serialize concurrent attempts.
-    // Compare expires_at to server-side NOW() to avoid JS/pg TZ drift on
-    // plain TIMESTAMP columns (client-side `new Date(row.expires_at)`
-    // silently reinterprets a naive timestamp as local time).
-    const challengeResult = await client.query<{
-      id: string;
-      expired: boolean;
-    }>(
-      `SELECT id, (expires_at < NOW()) AS expired FROM wallet_link_challenges
-       WHERE user_did = $1 AND chain = $2 AND wallet_address = $3 AND challenge = $4
-       FOR UPDATE`,
-      [userDid, chain, normalizedAddress, challenge]
-    );
-
-    if (challengeResult.rows.length === 0) {
-      await client.query('ROLLBACK');
-      return { success: false, error: 'Challenge not found or does not match' };
-    }
-
-    const row = challengeResult.rows[0];
-    if (row.expired) {
-      await client.query('DELETE FROM wallet_link_challenges WHERE id = $1', [row.id]);
-      await client.query('COMMIT');
-      return { success: false, error: 'Challenge has expired' };
-    }
-
-    // Check wallet is not already linked to a different DID
-    const existingLink = await client.query<{ user_did: string }>(
-      `SELECT user_did FROM wallet_links WHERE chain = $1 AND wallet_address = $2 FOR UPDATE`,
-      [chain, normalizedAddress]
-    );
-
-    if (existingLink.rows.length > 0 && existingLink.rows[0].user_did !== userDid) {
-      await client.query('ROLLBACK');
-      return { success: false, error: 'Wallet is already linked to a different identity' };
-    }
-
-    // Check label uniqueness for this user (if label provided)
-    if (label) {
-      const existingLabel = await client.query<{ id: string; chain: string; wallet_address: string }>(
-        `SELECT id, chain, wallet_address FROM wallet_links WHERE user_did = $1 AND label = $2`,
-        [userDid, label]
+    const outcome = await withTransaction<
+      { kind: 'ok' } | { kind: 'expired' }
+    >(async (client) => {
+      // Lock the challenge row to serialize concurrent attempts.
+      // Compare expires_at to server-side NOW() to avoid JS/pg TZ drift on
+      // plain TIMESTAMP columns (client-side `new Date(row.expires_at)`
+      // silently reinterprets a naive timestamp as local time).
+      const challengeResult = await client.query<{
+        id: string;
+        expired: boolean;
+      }>(
+        `SELECT id, (expires_at < NOW()) AS expired FROM wallet_link_challenges
+         WHERE user_did = $1 AND chain = $2 AND wallet_address = $3 AND challenge = $4
+         FOR UPDATE`,
+        [userDid, chain, normalizedAddress, challenge]
       );
-      // Allow re-linking the same wallet with same label, reject different wallet with same label
-      if (existingLabel.rows.length > 0) {
-        const existing = existingLabel.rows[0];
-        if (existing.chain !== chain || existing.wallet_address !== normalizedAddress) {
-          await client.query('ROLLBACK');
-          return { success: false, error: 'Label already in use for a different wallet' };
+
+      if (challengeResult.rows.length === 0) {
+        throw new WalletLinkRejection('Challenge not found or does not match');
+      }
+
+      const row = challengeResult.rows[0];
+      if (row.expired) {
+        await client.query('DELETE FROM wallet_link_challenges WHERE id = $1', [row.id]);
+        return { kind: 'expired' };
+      }
+
+      // Check wallet is not already linked to a different DID
+      const existingLink = await client.query<{ user_did: string }>(
+        `SELECT user_did FROM wallet_links WHERE chain = $1 AND wallet_address = $2 FOR UPDATE`,
+        [chain, normalizedAddress]
+      );
+
+      if (existingLink.rows.length > 0 && existingLink.rows[0].user_did !== userDid) {
+        throw new WalletLinkRejection('Wallet is already linked to a different identity');
+      }
+
+      // Check label uniqueness for this user (if label provided)
+      if (label) {
+        const existingLabel = await client.query<{ id: string; chain: string; wallet_address: string }>(
+          `SELECT id, chain, wallet_address FROM wallet_links WHERE user_did = $1 AND label = $2`,
+          [userDid, label]
+        );
+        // Allow re-linking the same wallet with same label, reject different wallet with same label
+        if (existingLabel.rows.length > 0) {
+          const existing = existingLabel.rows[0];
+          if (existing.chain !== chain || existing.wallet_address !== normalizedAddress) {
+            throw new WalletLinkRejection('Label already in use for a different wallet');
+          }
         }
       }
+
+      // Create the link (upsert by chain+wallet_address)
+      const id = randomUUID();
+      await client.query(
+        `INSERT INTO wallet_links (id, user_did, chain, wallet_address, label, challenge, signature)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT (chain, wallet_address) DO UPDATE SET
+           label = EXCLUDED.label,
+           challenge = EXCLUDED.challenge,
+           signature = EXCLUDED.signature,
+           linked_at = CURRENT_TIMESTAMP`,
+        [id, userDid, chain, normalizedAddress, label || null, challenge, signature]
+      );
+
+      // Clean up the challenge
+      await client.query('DELETE FROM wallet_link_challenges WHERE id = $1', [row.id]);
+
+      return { kind: 'ok' };
+    });
+
+    if (outcome.kind === 'expired') {
+      return { success: false, error: 'Challenge has expired' };
     }
-
-    // Create the link (upsert by chain+wallet_address)
-    const id = randomUUID();
-    await client.query(
-      `INSERT INTO wallet_links (id, user_did, chain, wallet_address, label, challenge, signature)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
-       ON CONFLICT (chain, wallet_address) DO UPDATE SET
-         label = EXCLUDED.label,
-         challenge = EXCLUDED.challenge,
-         signature = EXCLUDED.signature,
-         linked_at = CURRENT_TIMESTAMP`,
-      [id, userDid, chain, normalizedAddress, label || null, challenge, signature]
-    );
-
-    // Clean up the challenge
-    await client.query('DELETE FROM wallet_link_challenges WHERE id = $1', [row.id]);
-
-    await client.query('COMMIT');
     return { success: true };
   } catch (err) {
-    await client.query('ROLLBACK');
+    if (err instanceof WalletLinkRejection) {
+      return { success: false, error: err.reason };
+    }
     // Handle unique constraint violations gracefully
     if ((err as any)?.code === '23505') {
       return { success: false, error: 'Wallet link conflict — please retry' };
     }
     throw err;
-  } finally {
-    client.release();
   }
 }
 

--- a/src/oauth/oauth-store.ts
+++ b/src/oauth/oauth-store.ts
@@ -35,7 +35,7 @@ import type {
   ClientId,
 } from '@atproto/oauth-provider';
 
-import { query, getClient } from '../db/client.js';
+import { query, withTransaction } from '../db/client.js';
 import { hashPassword, verifyPassword } from '../auth/password.js';
 import { normalizeHandle } from '../auth/utils.js';
 import { createUserIdentity } from '../identity/user-identity.js';
@@ -71,26 +71,21 @@ export class PgAccountStore implements AccountStore {
       if (inv.expires_at && new Date(inv.expires_at) < new Date()) throw new Error('Invite code expired');
     }
 
-    const client = await getClient();
-    let identity: Awaited<ReturnType<typeof createUserIdentity>>;
     const userId = crypto.randomUUID();
-    try {
-      await client.query('BEGIN');
-
+    const identity = await withTransaction(async (client) => {
       await ensureHandleEmailAvailable(client, handle, email);
 
       const [createdIdentity, passwordHash] = await Promise.all([
         createUserIdentity(handle),
         hashPassword(password),
       ]);
-      identity = createdIdentity;
 
       await insertUserWithRole(client, {
         userId,
         handle,
         email,
         passwordHash,
-        did: identity.did,
+        did: createdIdentity.did,
         status: 'pending',
       });
 
@@ -101,13 +96,8 @@ export class PgAccountStore implements AccountStore {
         );
       }
 
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+      return createdIdentity;
+    });
 
     // Initialize signing key + repo outside the user-insert transaction.
     // Previously the OAuth path only stored the signing key and skipped
@@ -393,10 +383,7 @@ export class PgRequestStore implements RequestStore {
 
   async consumeRequestCode(code: Code): Promise<FoundRequestResult | null> {
     // Atomic: SELECT FOR UPDATE SKIP LOCKED to prevent concurrent consumption
-    const client = await getClient();
-    try {
-      await client.query('BEGIN');
-
+    return withTransaction(async (client) => {
       const result = await client.query<{ id: string; data: RequestData }>(
         `SELECT id, data FROM oauth_requests
          WHERE data->>'code' = $1
@@ -406,7 +393,6 @@ export class PgRequestStore implements RequestStore {
       );
 
       if (result.rows.length === 0) {
-        await client.query('ROLLBACK');
         return null;
       }
 
@@ -417,18 +403,11 @@ export class PgRequestStore implements RequestStore {
       // Delete bound device accounts
       await client.query('DELETE FROM oauth_device_accounts WHERE request_id = $1', [row.id]);
 
-      await client.query('COMMIT');
-
       return {
         requestId: row.id as RequestId,
         data: deserializeRequestData(row.data),
       };
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
   }
 }
 
@@ -503,10 +482,7 @@ export class PgTokenStore implements TokenStore {
     newRefreshToken: RefreshToken,
     newData: NewTokenData
   ): Promise<void> {
-    const client = await getClient();
-    try {
-      await client.query('BEGIN');
-
+    await withTransaction(async (client) => {
       // Get current token
       const current = await client.query<{ data: any; current_refresh_token: string | null }>(
         'SELECT data, current_refresh_token FROM oauth_tokens WHERE id = $1 FOR UPDATE',
@@ -514,7 +490,6 @@ export class PgTokenStore implements TokenStore {
       );
 
       if (current.rows.length === 0) {
-        await client.query('ROLLBACK');
         throw new Error('Token not found');
       }
 
@@ -538,14 +513,7 @@ export class PgTokenStore implements TokenStore {
         `UPDATE oauth_tokens SET id = $1, data = $2, current_refresh_token = $3 WHERE id = $4`,
         [newTokenId, JSON.stringify(mergedData), newRefreshToken, tokenId]
       );
-
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
   }
 
   async findTokenByRefreshToken(refreshToken: RefreshToken): Promise<null | TokenInfo> {

--- a/src/repo/block-cache.ts
+++ b/src/repo/block-cache.ts
@@ -1,0 +1,65 @@
+/**
+ * Process-wide block cache for MST traversal.
+ *
+ * AT Protocol repo blocks are content-addressed — the CID is a hash of
+ * the block bytes. That means a block at CID X always has the same
+ * content; once we've fetched it, we can keep it in memory indefinitely
+ * without invalidation. The only failure mode is unbounded memory
+ * growth, which we cap with simple insertion-order eviction (~LRU
+ * for our usage pattern, where reads tend to hit the same recent CIDs).
+ *
+ * Why this matters: every record write triggers `Repo.load(storage)`,
+ * which fetches the root block and then walks the MST until it finds
+ * the right node. For a 10K-member community that can be many block
+ * fetches per write. With this cache, the second write to the same
+ * repo (within the same 30 minutes or so of activity) does ~zero
+ * database I/O for the MST traversal — only the new commit's writes
+ * hit Postgres.
+ *
+ * Keying by (did, cid) rather than just cid: our `repo_blocks` table
+ * is partitioned per DID. Two communities with the same block content
+ * have distinct rows, and we don't want one community's cache to mask
+ * another's missing block (would return wrong "not missing" answers).
+ */
+
+const MAX_ENTRIES = 10_000;
+
+const cache = new Map<string, Uint8Array>();
+
+function key(did: string, cidStr: string): string {
+  return `${did}::${cidStr}`;
+}
+
+export function blockCacheGet(did: string, cidStr: string): Uint8Array | undefined {
+  return cache.get(key(did, cidStr));
+}
+
+export function blockCacheSet(did: string, cidStr: string, bytes: Uint8Array): void {
+  if (cache.size >= MAX_ENTRIES) {
+    // Evict oldest insertion. Map iteration order is insertion order.
+    const firstKey = cache.keys().next().value;
+    if (firstKey) cache.delete(firstKey);
+  }
+  cache.set(key(did, cidStr), bytes);
+}
+
+/**
+ * Drop a block from the cache after the underlying DB row is deleted.
+ * Correctness doesn't strictly require this — removed blocks aren't
+ * referenced by the current MST and won't be queried by `getBytes` —
+ * but it keeps memory usage tidy on long-lived processes.
+ */
+export function blockCacheDelete(did: string, cidStr: string): void {
+  cache.delete(key(did, cidStr));
+}
+
+/**
+ * Test helper. Not part of the regular interface.
+ */
+export function _clearBlockCache(): void {
+  cache.clear();
+}
+
+export function _blockCacheSize(): number {
+  return cache.size;
+}

--- a/src/repo/pg-blockstore.ts
+++ b/src/repo/pg-blockstore.ts
@@ -9,6 +9,7 @@
 import { CID } from 'multiformats/cid';
 import { ReadableBlockstore, RepoStorage, BlockMap, CommitData } from '@atproto/repo';
 import { query, withTransaction } from '../db/client.js';
+import { blockCacheGet, blockCacheSet, blockCacheDelete } from './block-cache.js';
 
 export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
   constructor(private did: string) {
@@ -26,12 +27,17 @@ export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
 
   async getBytes(cid: CID): Promise<Uint8Array | null> {
     const cidStr = cid.toString();
+    const cached = blockCacheGet(this.did, cidStr);
+    if (cached) return cached;
+
     const result = await query<{ block_bytes: Buffer }>(
       'SELECT block_bytes FROM repo_blocks WHERE community_did = $1 AND cid = $2',
       [this.did, cidStr]
     );
     if (result.rows.length === 0) return null;
-    return new Uint8Array(result.rows[0].block_bytes);
+    const bytes = new Uint8Array(result.rows[0].block_bytes);
+    blockCacheSet(this.did, cidStr, bytes);
+    return bytes;
   }
 
   async has(cid: CID): Promise<boolean> {
@@ -48,22 +54,40 @@ export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
       return { blocks: new BlockMap(), missing: [] };
     }
 
-    const cidStrs = cids.map(c => c.toString());
+    const blocks = new BlockMap();
+    const toFetch: CID[] = [];
+
+    // Serve cached blocks immediately; only query for misses.
+    for (const cid of cids) {
+      const cidStr = cid.toString();
+      const cached = blockCacheGet(this.did, cidStr);
+      if (cached) {
+        blocks.set(cid, cached);
+      } else {
+        toFetch.push(cid);
+      }
+    }
+
+    if (toFetch.length === 0) {
+      return { blocks, missing: [] };
+    }
+
+    const cidStrs = toFetch.map(c => c.toString());
     const result = await query<{ cid: string; block_bytes: Buffer }>(
       'SELECT cid, block_bytes FROM repo_blocks WHERE community_did = $1 AND cid = ANY($2)',
       [this.did, cidStrs]
     );
 
-    const blocks = new BlockMap();
     const foundSet = new Set<string>();
-
     for (const row of result.rows) {
       foundSet.add(row.cid);
       const cid = CID.parse(row.cid);
-      blocks.set(cid, new Uint8Array(row.block_bytes));
+      const bytes = new Uint8Array(row.block_bytes);
+      blocks.set(cid, bytes);
+      blockCacheSet(this.did, row.cid, bytes);
     }
 
-    const missing = cids.filter(c => !foundSet.has(c.toString()));
+    const missing = toFetch.filter(c => !foundSet.has(c.toString()));
     return { blocks, missing };
   }
 
@@ -75,6 +99,9 @@ export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
        ON CONFLICT (community_did, cid) DO UPDATE SET block_bytes = $3, rev = $4`,
       [this.did, cidStr, Buffer.from(block), rev]
     );
+    // Populate cache so the immediately-following Repo.load reads from
+    // memory instead of round-tripping to Postgres.
+    blockCacheSet(this.did, cidStr, block);
   }
 
   async putMany(blocks: BlockMap, rev: string): Promise<void> {
@@ -106,6 +133,11 @@ export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
         );
       }
     });
+    // Populate cache after the transaction commits, so cached entries
+    // never lead a reader to assume a block is durable when it isn't.
+    for (const [cid, bytes] of blocks) {
+      blockCacheSet(this.did, cid.toString(), bytes);
+    }
   }
 
   async updateRoot(cid: CID, rev: string): Promise<void> {
@@ -163,5 +195,15 @@ export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
         [this.did, cidStr, commit.rev]
       );
     });
+    // Populate cache for the new blocks so the next Repo.load() walks
+    // the MST entirely from memory.
+    for (const [cid, bytes] of commit.newBlocks) {
+      blockCacheSet(this.did, cid.toString(), bytes);
+    }
+    // Drop removed blocks so we don't pay RAM for content that's been
+    // unlinked from the current MST.
+    for (const cid of commit.removedCids.toList()) {
+      blockCacheDelete(this.did, cid.toString());
+    }
   }
 }

--- a/src/repo/pg-blockstore.ts
+++ b/src/repo/pg-blockstore.ts
@@ -8,7 +8,7 @@
 
 import { CID } from 'multiformats/cid';
 import { ReadableBlockstore, RepoStorage, BlockMap, CommitData } from '@atproto/repo';
-import { getClient, query } from '../db/client.js';
+import { query, withTransaction } from '../db/client.js';
 
 export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
   constructor(private did: string) {
@@ -80,10 +80,7 @@ export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
   async putMany(blocks: BlockMap, rev: string): Promise<void> {
     if (blocks.size === 0) return;
 
-    const client = await getClient();
-    try {
-      await client.query('BEGIN');
-
+    await withTransaction(async (client) => {
       // Batch blocks into multi-row INSERTs (max 100 per statement to stay
       // well under PostgreSQL's ~65535 parameter limit: 100 rows * 4 params = 400)
       const entries = Array.from(blocks);
@@ -108,14 +105,7 @@ export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
           values
         );
       }
-
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
   }
 
   async updateRoot(cid: CID, rev: string): Promise<void> {
@@ -129,10 +119,7 @@ export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
   }
 
   async applyCommit(commit: CommitData): Promise<void> {
-    const client = await getClient();
-    try {
-      await client.query('BEGIN');
-
+    await withTransaction(async (client) => {
       // Batch-insert new blocks
       const newEntries = Array.from(commit.newBlocks);
       const BATCH_SIZE = 100;
@@ -175,13 +162,6 @@ export class PgBlockstore extends ReadableBlockstore implements RepoStorage {
          ON CONFLICT (did) DO UPDATE SET root_cid = $2, rev = $3, updated_at = CURRENT_TIMESTAMP`,
         [this.did, cidStr, commit.rev]
       );
-
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
   }
 }

--- a/src/repo/repo-engine.ts
+++ b/src/repo/repo-engine.ts
@@ -21,7 +21,9 @@ import type {
 } from '@atproto/repo';
 import type { Keypair } from '@atproto/crypto';
 import { PgBlockstore } from './pg-blockstore.js';
-import { query, getClient } from '../db/client.js';
+import { query, withTransaction } from '../db/client.js';
+
+const MEMBER_COLLECTION = 'net.openfederation.community.member';
 
 export class RepoEngine {
   private storage: PgBlockstore;
@@ -232,52 +234,72 @@ export class RepoEngine {
   }
 
   /**
-   * Sync the records_index cache after write operations.
-   * The MST is the source of truth; records_index is a denormalized read cache.
+   * Sync the records_index cache after write operations. The MST is the
+   * source of truth; records_index is a denormalized read cache. For
+   * member-collection records, also fan out role/kind/tags/attributes to
+   * the `members_unique` projection so handlers don't have to remember
+   * to sync separately. Display fields (display_name/avatar_url) are
+   * fanned out by `fanOutDisplayFields` from the profile-update handler
+   * — that projection crosses DIDs and lives outside the engine.
    */
   private async syncRecordsIndex(
     ops: Array<{ action: string; collection: string; rkey: string; record?: Record<string, unknown>; cid?: string }>
   ): Promise<void> {
-    const client = await getClient();
-    try {
-      await client.query('BEGIN');
-
+    await withTransaction(async (client) => {
       for (const op of ops) {
         if (op.action === WriteOpAction.Delete) {
           await client.query(
             'DELETE FROM records_index WHERE community_did = $1 AND collection = $2 AND rkey = $3',
             [this.did, op.collection, op.rkey]
           );
-        } else if (op.record) {
-          // Use pre-computed CID if available, otherwise compute
-          const cidStr = op.cid || (await cidForRecord(op.record)).toString();
+          continue;
+        }
+        if (!op.record) continue;
+
+        const cidStr = op.cid || (await cidForRecord(op.record)).toString();
+
+        await client.query(
+          `INSERT INTO records_index (community_did, collection, rkey, cid, record, updated_at)
+           VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)
+           ON CONFLICT (community_did, collection, rkey)
+           DO UPDATE SET cid = $4, record = $5, updated_at = CURRENT_TIMESTAMP`,
+          [this.did, op.collection, op.rkey, cidStr, JSON.stringify(op.record)]
+        );
+
+        if (op.collection === MEMBER_COLLECTION && op.record.did) {
+          const rec = op.record as {
+            did: string;
+            role?: string | null;
+            roleRkey?: string | null;
+            kind?: string | null;
+            tags?: string[] | null;
+            attributes?: Record<string, unknown> | null;
+          };
 
           await client.query(
-            `INSERT INTO records_index (community_did, collection, rkey, cid, record, updated_at)
-             VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)
-             ON CONFLICT (community_did, collection, rkey)
-             DO UPDATE SET cid = $4, record = $5, updated_at = CURRENT_TIMESTAMP`,
-            [this.did, op.collection, op.rkey, cidStr, JSON.stringify(op.record)]
+            `INSERT INTO members_unique
+               (community_did, member_did, record_rkey, role, role_rkey, kind, tags, attributes)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             ON CONFLICT (community_did, member_did) DO UPDATE
+               SET record_rkey = EXCLUDED.record_rkey,
+                   role        = COALESCE(EXCLUDED.role, members_unique.role),
+                   role_rkey   = EXCLUDED.role_rkey,
+                   kind        = EXCLUDED.kind,
+                   tags        = EXCLUDED.tags,
+                   attributes  = EXCLUDED.attributes`,
+            [
+              this.did,
+              rec.did,
+              op.rkey,
+              rec.role ?? null,
+              rec.roleRkey ?? null,
+              rec.kind ?? null,
+              rec.tags ? JSON.stringify(rec.tags) : null,
+              rec.attributes ? JSON.stringify(rec.attributes) : null,
+            ],
           );
-
-          // Sync members_unique table for member records
-          if (op.collection === 'net.openfederation.community.member' && op.record.did) {
-            await client.query(
-              `INSERT INTO members_unique (community_did, member_did, record_rkey)
-               VALUES ($1, $2, $3)
-               ON CONFLICT (community_did, member_did) DO NOTHING`,
-              [this.did, op.record.did as string, op.rkey]
-            );
-          }
         }
       }
-
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
+    });
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -227,6 +227,11 @@ app.use(async (req, res, next) => {
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, DPoP, X-Partner-Key');
   res.setHeader('Access-Control-Expose-Headers', 'DPoP-Nonce, WWW-Authenticate');
+  // Cache the CORS preflight for 24h so cross-origin POSTs from the SDK
+  // and Web UI don't pay an OPTIONS round-trip on every call. Vary by
+  // origin so browsers don't cross-pollinate per-origin responses.
+  res.setHeader('Access-Control-Max-Age', '86400');
+  res.setHeader('Vary', 'Origin');
   if (req.method === 'OPTIONS') { res.status(204).end(); return; }
   next();
 });

--- a/src/wallet/eligibility.ts
+++ b/src/wallet/eligibility.ts
@@ -1,0 +1,89 @@
+/**
+ * Custodial signing eligibility — the single check that gates every
+ * server-side wallet signing operation.
+ *
+ * Both `wallet.sign` (arbitrary-message signing) and `wallet.signTransaction`
+ * need the exact same answer to: "is the PDS allowed to sign with this
+ * wallet for this dApp right now?" The answer is yes iff
+ *
+ *   - the wallet is linked to this DID (otherwise: WalletNotFound)
+ *   - the wallet's custody is active (otherwise: WalletInactive)
+ *   - the wallet is Tier 1 custodial (otherwise: UnsupportedTier — Tier 2/3
+ *     wallets sign client-side, the PDS holds no key to use)
+ *   - an unrevoked consent grant exists for this dApp + wallet
+ *     (otherwise: ConsentRequired)
+ *
+ * The result is a typed `WalletEligibilityRejection`; handlers translate
+ * it into an `XrpcError` against their NSID. Both NSIDs declare the same
+ * four error codes used here.
+ */
+
+import { hasActiveConsent } from './consent.js';
+import { getWalletTier } from './linking.js';
+import type { WalletChain } from './types.js';
+
+export type WalletEligibilityRejectionCode =
+  | 'WalletNotFound'
+  | 'WalletInactive'
+  | 'UnsupportedTier'
+  | 'ConsentRequired';
+
+export class WalletEligibilityRejection extends Error {
+  constructor(
+    public readonly code: WalletEligibilityRejectionCode,
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'WalletEligibilityRejection';
+  }
+}
+
+export interface SigningEligibilityInput {
+  userDid: string;
+  chain: WalletChain;
+  walletAddress: string;   // Already normalized (lowercase for ethereum)
+  dappOrigin: string;      // Already normalized
+}
+
+/**
+ * Throws `WalletEligibilityRejection` if the caller is not allowed to
+ * trigger a custodial signing operation. Returns void on success.
+ */
+export async function assertCustodialSigningEligible(
+  opts: SigningEligibilityInput,
+): Promise<void> {
+  const tierInfo = await getWalletTier(opts.userDid, opts.chain, opts.walletAddress);
+  if (!tierInfo) {
+    throw new WalletEligibilityRejection('WalletNotFound', 404, 'No such wallet for this DID');
+  }
+  if (tierInfo.status !== 'active') {
+    throw new WalletEligibilityRejection(
+      'WalletInactive',
+      409,
+      `Wallet is ${tierInfo.status} and cannot be signed with`,
+    );
+  }
+  if (tierInfo.tier !== 'custodial') {
+    throw new WalletEligibilityRejection(
+      'UnsupportedTier',
+      409,
+      tierInfo.tier === 'user_encrypted'
+        ? 'Tier 2 wallets must sign client-side via the SDK (unlock + signMessage)'
+        : 'Tier 3 wallets are self-custodial — use your own wallet software to sign',
+    );
+  }
+  const consented = await hasActiveConsent({
+    userDid: opts.userDid,
+    dappOrigin: opts.dappOrigin,
+    chain: opts.chain,
+    walletAddress: opts.walletAddress,
+  });
+  if (!consented) {
+    throw new WalletEligibilityRejection(
+      'ConsentRequired',
+      403,
+      'No active consent grants this dApp permission to sign with this wallet',
+    );
+  }
+}

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -2,3 +2,4 @@ export * from './types.js';
 export * from './custody.js';
 export * from './consent.js';
 export * from './linking.js';
+export * from './eligibility.js';

--- a/src/wallet/linking.ts
+++ b/src/wallet/linking.ts
@@ -11,7 +11,9 @@
  */
 
 import { randomUUID } from 'crypto';
-import { query, getClient } from '../db/client.js';
+import { query, withTransaction } from '../db/client.js';
+
+class CustodialLinkRejection extends Error {}
 import { Wallet } from 'ethers';
 import nacl from 'tweetnacl';
 import bs58 from 'bs58';
@@ -63,59 +65,51 @@ export async function linkCustodialWallet(opts: {
     return { success: false, error: `Failed to sign link challenge: ${(err as Error).message}` };
   }
 
-  const client = await getClient();
   try {
-    await client.query('BEGIN');
-
-    // Ensure the address isn't already bound to a different DID.
-    const existing = await client.query<{ user_did: string }>(
-      `SELECT user_did FROM wallet_links
-       WHERE chain = $1 AND wallet_address = $2
-       FOR UPDATE`,
-      [chain, walletAddress]
-    );
-    if (existing.rows.length > 0 && existing.rows[0].user_did !== userDid) {
-      await client.query('ROLLBACK');
-      return { success: false, error: 'Wallet address already linked to a different identity' };
-    }
-
-    if (label) {
-      const labelConflict = await client.query<{ chain: string; wallet_address: string }>(
-        `SELECT chain, wallet_address FROM wallet_links
-         WHERE user_did = $1 AND label = $2`,
-        [userDid, label]
+    await withTransaction(async (client) => {
+      // Ensure the address isn't already bound to a different DID.
+      const existing = await client.query<{ user_did: string }>(
+        `SELECT user_did FROM wallet_links
+         WHERE chain = $1 AND wallet_address = $2
+         FOR UPDATE`,
+        [chain, walletAddress]
       );
-      if (labelConflict.rows.length > 0) {
-        const prev = labelConflict.rows[0];
-        if (prev.chain !== chain || prev.wallet_address !== walletAddress) {
-          await client.query('ROLLBACK');
-          return { success: false, error: 'Label already in use for a different wallet' };
+      if (existing.rows.length > 0 && existing.rows[0].user_did !== userDid) {
+        throw new CustodialLinkRejection('Wallet address already linked to a different identity');
+      }
+
+      if (label) {
+        const labelConflict = await client.query<{ chain: string; wallet_address: string }>(
+          `SELECT chain, wallet_address FROM wallet_links
+           WHERE user_did = $1 AND label = $2`,
+          [userDid, label]
+        );
+        if (labelConflict.rows.length > 0) {
+          const prev = labelConflict.rows[0];
+          if (prev.chain !== chain || prev.wallet_address !== walletAddress) {
+            throw new CustodialLinkRejection('Label already in use for a different wallet');
+          }
         }
       }
-    }
 
-    const id = randomUUID();
-    await client.query(
-      `INSERT INTO wallet_links
-         (id, user_did, chain, wallet_address, label, challenge, signature, custody_tier, custody_status)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, 'custodial', 'active')
-       ON CONFLICT (chain, wallet_address) DO UPDATE SET
-         label = EXCLUDED.label,
-         challenge = EXCLUDED.challenge,
-         signature = EXCLUDED.signature,
-         custody_tier = EXCLUDED.custody_tier,
-         custody_status = 'active',
-         linked_at = CURRENT_TIMESTAMP`,
-      [id, userDid, chain, walletAddress, label ?? null, challenge, signature]
-    );
-
-    await client.query('COMMIT');
+      const id = randomUUID();
+      await client.query(
+        `INSERT INTO wallet_links
+           (id, user_did, chain, wallet_address, label, challenge, signature, custody_tier, custody_status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, 'custodial', 'active')
+         ON CONFLICT (chain, wallet_address) DO UPDATE SET
+           label = EXCLUDED.label,
+           challenge = EXCLUDED.challenge,
+           signature = EXCLUDED.signature,
+           custody_tier = EXCLUDED.custody_tier,
+           custody_status = 'active',
+           linked_at = CURRENT_TIMESTAMP`,
+        [id, userDid, chain, walletAddress, label ?? null, challenge, signature]
+      );
+    });
     return { success: true };
   } catch (err) {
-    await client.query('ROLLBACK');
     return { success: false, error: (err as Error).message };
-  } finally {
-    client.release();
   }
 }
 

--- a/web-interface/src/app/(dashboard)/page.tsx
+++ b/web-interface/src/app/(dashboard)/page.tsx
@@ -16,7 +16,7 @@ export default function DashboardPage() {
   const handle = useAuthStore((s) => s.handle);
   const isAdmin = useAuthStore((s) => s.isAdmin);
   const { data: myCommunities, isLoading: commLoading } = useMyCommunitiesQuery(6, 0);
-  const { data: serverConfig, isLoading: configLoading } = useServerConfigQuery();
+  const { data: serverConfig, isLoading: configLoading } = useServerConfigQuery({ enabled: isAdmin });
 
   return (
     <div>

--- a/web-interface/src/components/auth-guard.tsx
+++ b/web-interface/src/components/auth-guard.tsx
@@ -6,15 +6,19 @@ import { useAuthStore } from '@/store/auth-store';
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isHydrated = useAuthStore((s) => s.isHydrated);
   const router = useRouter();
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    // Don't bounce to /login until the persisted store has rehydrated;
+    // otherwise authenticated users see a flash of the login page on
+    // every cold load.
+    if (isHydrated && !isAuthenticated) {
       router.replace('/login');
     }
-  }, [isAuthenticated, router]);
+  }, [isHydrated, isAuthenticated, router]);
 
-  if (!isAuthenticated) {
+  if (!isHydrated || !isAuthenticated) {
     return null;
   }
 

--- a/web-interface/src/components/community-card.tsx
+++ b/web-interface/src/components/community-card.tsx
@@ -1,4 +1,8 @@
+'use client';
+
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import type { CommunityListItem } from '@/lib/api/types';
 import {
   Card,
@@ -7,10 +11,29 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { communityKeys } from '@/hooks/use-communities';
+import { getCommunity } from '@/lib/api/communities';
+import { unwrapApi } from '@/lib/api/unwrap';
 
 export function CommunityCard({ community }: { community: CommunityListItem }) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const href = `/communities/${encodeURIComponent(community.did)}`;
+
+  // Prefetch the route bundle + the detail data the moment the user
+  // intends to navigate (hover or focus). On click the page renders
+  // from cache instead of waiting for the round-trip.
+  const prefetch = () => {
+    router.prefetch(href);
+    queryClient.prefetchQuery({
+      queryKey: communityKeys.detail(community.did),
+      queryFn: async () => unwrapApi(await getCommunity(community.did)),
+      staleTime: 60 * 1000,
+    });
+  };
+
   return (
-    <Link href={`/communities/${encodeURIComponent(community.did)}`}>
+    <Link href={href} prefetch onMouseEnter={prefetch} onFocus={prefetch}>
       <Card className="hover:bg-muted/50 transition-colors">
         <CardHeader className="pb-2">
           <div className="flex items-center justify-between">

--- a/web-interface/src/hooks/use-server-config.ts
+++ b/web-interface/src/hooks/use-server-config.ts
@@ -2,10 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 import { getServerConfig } from '@/lib/api/admin';
 import { unwrapApi } from '@/lib/api/unwrap';
 
-export function useServerConfigQuery() {
+/**
+ * Server config + admin-only stats. Pass `enabled: false` from non-admin
+ * call sites to skip the request entirely — the response is admin/auditor
+ * gated server-side, so non-admins would just get a 403.
+ */
+export function useServerConfigQuery(opts: { enabled?: boolean } = {}) {
   return useQuery({
     queryKey: ['server-config'],
     queryFn: async () => unwrapApi(await getServerConfig()),
-    staleTime: 60 * 1000,
+    // Server config + counts move slowly; 5 min keeps tab-switches snappy.
+    staleTime: 5 * 60 * 1000,
+    enabled: opts.enabled ?? true,
   });
 }

--- a/web-interface/src/providers/query-provider.tsx
+++ b/web-interface/src/providers/query-provider.tsx
@@ -9,8 +9,13 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: 30 * 1000,
-            gcTime: 5 * 60 * 1000,
+            // 60s default keeps tab-switches snappy without showing stale
+            // data for long. Hooks that touch slow-moving data (server
+            // config, peer communities) override with longer windows.
+            // refetchOnWindowFocus: true respects staleTime — focus only
+            // triggers a refetch when the data is actually stale.
+            staleTime: 60 * 1000,
+            gcTime: 10 * 60 * 1000,
             refetchOnWindowFocus: true,
             retry: 1,
           },


### PR DESCRIPTION
Two related streams of work, layered as 8 independent commits so any one can be reverted on its own.

## Architecture deepening (3 commits)

1. **`6cd0db2`** — `withTransaction(fn)` helper in `src/db/client.ts`. Throw to roll back, return to commit, connection always released. Convert `account.register` and `partner.register`. Move `RepoEngine.syncRecordsIndex` to use it and absorb the member-record projection (role/role_rkey/kind/tags/attributes) so handlers writing member records can't forget to sync — `syncMemberRoleProjection` is deleted.
2. **`7e11d4a`** — Convert the remaining 10 raw `BEGIN/COMMIT/ROLLBACK` sites in the codebase. The only `BEGIN` left in `src/` is inside the helper itself. Early-return-style handlers throw typed `XrpcError`; service modules use small private rejection classes to preserve their `{ success, error }` contracts.
3. **`c363e48`** — Extract `assertCustodialSigningEligible()` in `src/wallet/eligibility.ts`. Two adapters (`wallet.sign` + `wallet.signTransaction`) shared an identical 40-line tier+status+consent block. KYC, geo-restrictions, per-wallet rate limits all have one place to land now.

## Performance wins (5 commits)

Targeted at the user-felt latency in OAuth/federation/Web-UI paths.

4. **`4806166`** — `perf(ui)`: AuthGuard waits for store rehydration (fixes login-flash bug); `useServerConfigQuery` accepts `enabled` so non-admins skip a doomed admin call; `staleTime` 30s→60s; `CommunityCard` prefetches detail data on hover/focus.
5. **`6198e03`** — `perf(identity)`: race DNS TXT and HTTPS well-known in parallel for external handle resolution; 1-min negative cache so typo'd handles don't pay the full timeout on every retry; overall timeout 3s→2s.
6. **`6dbc561`** — `perf(auth)`: DID→AuthContext cache (60s TTL) for OAuth + service-auth callers. Local Bearer JWT auth was already free; this closes the gap for cross-PDS federation and external-OAuth users who paid 2 sequential SQL queries per request. Explicit invalidation wired into the four endpoints that change status/roles.
7. **`6c1fa52`** — `perf(repo)`: process-wide block cache (10K cap) keyed by `(did, cid)`. Blocks are content-addressed, so cached entries are correct indefinitely. After warmup `Repo.load()` walks the MST entirely from memory.
8. **`78dbb6f`** — `perf(cors)`: `Access-Control-Max-Age: 86400` + `Vary: Origin`; partner-origin cache deduplicates concurrent refreshes via in-flight promise.

## Verification

- 598 API tests across 65 files pass
- 92 security tests pass
- Production build clean
- Type-check clean

## Knowingly NOT included

- **Per-DID write mutex**: concurrent writes to the same repo race on `Repo.load → applyWrites → updateRoot`. Pre-existing correctness gap, not introduced or worsened here. Worth a follow-up alongside the block cache.
- **`initialData` from list to detail**: hover prefetch covers most of the win; initial-data plumbing only helps cold cases where the user clicks faster than they hover.

## Test plan

- [ ] CI passes on the branch
- [ ] Local smoke: `npm run dev` + open Web UI; verify community list → detail navigation feels instant after first hover
- [ ] Spot-check OAuth login flow (cached AuthContext shouldn't change semantics)
- [ ] Spot-check `wallet.sign` and `wallet.signTransaction` end-to-end with a Tier 1 wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)